### PR TITLE
reversed the meaning of class 1

### DIFF
--- a/RuleListClassifier.py
+++ b/RuleListClassifier.py
@@ -127,8 +127,8 @@ class RuleListClassifier(BaseEstimator):
         data = list(X[:])
         #Now find frequent itemsets
         #Mine separately for each class
-        data_pos = [x for i,x in enumerate(data) if y[i]==0]
-        data_neg = [x for i,x in enumerate(data) if y[i]==1]
+        data_pos = [x for i,x in enumerate(data) if y[i]==1]
+        data_neg = [x for i,x in enumerate(data) if y[i]==0]
         assert len(data_pos)+len(data_neg) == len(data)
         try:
             itemsets = [r[0] for r in fpgrowth(data_pos,supp=self.minsupport,zmin=self._zmin,zmax=self.maxcardinality)]


### PR DESCRIPTION
The meaning of the class 1 is reversed.

verified with this small program:
from RuleListClassifier import *

labels = ['temp','size']
X =   [[100,12],
        [12,91],
        [17,92]]

Y =   [1,
        0,
        0]
clf = RuleListClassifier(max_iter=50000, n_chains=3, class1label='burned', verbose=False)
clf.fit(X, Y, feature_labels=labels)
print clf
# prints:

IF temp : 58.5_to_inf AND size : -inf_to_51.5 THEN probability of burned: 33.3% (1.3%-84.2%)
ELSE IF temp : -inf_to_58.5 AND size : 51.5_to_inf THEN probability of burned: 75.0% (29.2%-99.2%)
# ELSE probability of burned: 50.0% (2.5%-97.5%)

i.e. the meaning of the class 1 is reversed
